### PR TITLE
Fixes bug that skips SNPs at first read position

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Options:
                 Includes indels that are the only polymorphism at the locus
                 (contig)
 
+     --use_only_paired
+                Use only reads where both pairs are aligned at the locus
+
     -c, --complex
                 Specify how to treat complex polymorphisms in the VCF file
                 (indels, muliallelic SNPs, or complex polymorphims). The two


### PR DESCRIPTION
Fixes bug that skips SNPs at first read position that has to do with the fact that Bio::Cigar is 1-indexed rather than 0-indexed. 

Also added an option to specify whether only paired reads should be used for haplotyping.
